### PR TITLE
draco 1.5.6

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,18 +1,34 @@
+:: cmd
+echo "Building %PKG_NAME%."
+
 mkdir build
 cd build
+if errorlevel 1 exit /b 1
 
-cmake -G "NMake Makefiles" ^
+:: Generate the build files.
+echo "Generating the build files..."
+cmake .. %CMAKE_ARGS% ^
+      -G"Ninja" ^
       -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
       -DCMAKE_BUILD_TYPE:STRING=Release ^
       -DCMAKE_LIBRARY_PATH="%LIBRARY_LIB%" ^
       -DCMAKE_INCLUDE_PATH="%INCLUDE_INC%" ^
       -DBUILD_SHARED_LIBS=OFF ^
       %SRC_DIR%
-if errorlevel 1 exit 1
+if errorlevel 1 exit /b 1
 
-nmake
-if errorlevel 1 exit 1
+:: Build.
+echo "Building..."
+ninja -j%CPU_COUNT%
+if errorlevel 1 exit /b 1
 
-nmake install
-if errorlevel 1 exit 1
 
+:: Install.
+echo "Installing..."
+ninja install
+if errorlevel 1 exit /b 1
+
+
+:: Error free exit.
+echo "Error free exit!"
+exit 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/google/draco/archive/{{ version }}.tar.gz
+  url: https://github.com/google/{{ name }}/archive/{{ version }}.tar.gz
   sha256: 0280888e5b8e4c4fb93bf40e65e4e8a1ba316a0456f308164fb5c2b2b0c282d6
   patches:
     - start-group.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make      # [not win]
+    - ninja     # [win]
     - m2-patch  # [win]
     - patch     # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,11 @@ build:
 
 requirements:
   build:
-    - cmake
-    - make
     - {{ compiler('cxx') }}
+    - cmake
+    - make      # [not win]
+    - m2-patch  # [win]
+    - patch     # [not win]
 
 test:
   commands:


### PR DESCRIPTION
`pdal` package requires `draco`

Changelog: https://github.com/google/draco/releases
License: https://github.com/google/draco/blob/1.5.6/LICENSE
Requirements:
- https://github.com/google/draco/blob/1.5.6/BUILDING.md
- https://github.com/google/draco/blob/1.5.6/CMAKE.md
- https://github.com/google/draco/blob/1.5.6/CMakeLists.txt

Actions:
1. Add `patch` to `build`
2. Use `make` on `unix` only